### PR TITLE
Add associated primary volume to EarningsTracker

### DIFF
--- a/Boss/Mod/ForwardFeeMonitor.cpp
+++ b/Boss/Mod/ForwardFeeMonitor.cpp
@@ -25,6 +25,7 @@ void ForwardFeeMonitor::start() {
 		auto in_scid = Ln::Scid();
 		auto out_scid = Ln::Scid();
 		auto fee = Ln::Amount();
+		auto amount = Ln::Amount();
 		auto resolution_time = double();
 		try {
 			auto payload = n.params["forward_event"];
@@ -45,6 +46,9 @@ void ForwardFeeMonitor::start() {
 			));
 			fee = Ln::Amount::object(
 				payload["fee_msat"]
+			);
+			amount = Ln::Amount::object(
+				payload["out_msat"]
 			);
 			resolution_time = double(payload["resolved_time"])
 					- double(payload["received_time"])
@@ -70,11 +74,13 @@ void ForwardFeeMonitor::start() {
 			      ).then([ this
 				     , fee
 				     , resolution_time
+				     , amount
 				     ](std::vector<Ln::NodeId> nids) {
 			return cont( std::move(nids[0])
 				   , std::move(nids[1])
 				   , fee
 				   , resolution_time
+				   , amount
 				   );
 		});
 	});
@@ -84,6 +90,7 @@ Ev::Io<void> ForwardFeeMonitor::cont( Ln::NodeId in_id
 				    , Ln::NodeId out_id
 				    , Ln::Amount fee
 				    , double resolution_time
+				    , Ln::Amount amount
 				    ) {
 	if (!in_id || !out_id)
 		return Ev::lift();
@@ -101,7 +108,8 @@ Ev::Io<void> ForwardFeeMonitor::cont( Ln::NodeId in_id
 		std::move(in_id),
 		std::move(out_id),
 		fee,
-		resolution_time
+		resolution_time,
+		amount
 	}));
 	return act;
 }

--- a/Boss/Mod/ForwardFeeMonitor.hpp
+++ b/Boss/Mod/ForwardFeeMonitor.hpp
@@ -29,6 +29,7 @@ private:
 			 , Ln::NodeId out_id
 			 , Ln::Amount fee
 			 , double resolution_time
+			 , Ln::Amount amount
 			 );
 
 public:

--- a/Boss/Msg/ForwardFee.hpp
+++ b/Boss/Msg/ForwardFee.hpp
@@ -21,6 +21,8 @@ struct ForwardFee {
 	/* The time, in seconds, it took from us receiving the incoming HTLC
 	 * to us receiving the preimage from the outgoing HTLC.  */
 	double resolution_time;
+	/* The amount forwarded.  */
+	Ln::Amount amount;
 };
 
 }}

--- a/Boss/Msg/ResponseEarningsInfo.hpp
+++ b/Boss/Msg/ResponseEarningsInfo.hpp
@@ -30,6 +30,11 @@ struct ResponseEarningsInfo {
 	Ln::Amount out_earnings;
 	/* How much we have spent on rebalancing *to* this node.  */
 	Ln::Amount out_expenditures;
+
+	Ln::Amount in_forwarded;	// Amount forwarded inward to earn fees
+	Ln::Amount in_rebalanced; 	// Amount inward rebalanced for expenditure
+	Ln::Amount out_forwarded;	// Amount forwarded outward to earn fees
+	Ln::Amount out_rebalanced;	// Amount outward rebalanced for expenditure
 };
 
 }}

--- a/tests/boss/test_earningshistory.cpp
+++ b/tests/boss/test_earningshistory.cpp
@@ -38,8 +38,9 @@ Ev::Io<void> raiseForwardFeeLoop(S::Bus& bus, int count) {
 	return bus.raise(Boss::Msg::ForwardFee{
 			A,              	// in_id
 			B,              	// out_id
-			Ln::Amount::sat(1),	// fee
-			1.0             	// resolution_time
+			Ln::Amount::sat(2),	// fee
+			1.0,             	// resolution_time
+			Ln::Amount::sat(1000),	// fee
 		})
 		.then([&, count]() {
 			mock_now += 60 * 60;
@@ -64,7 +65,7 @@ Ev::Io<void> raiseMoveFundsLoop(S::Bus& bus, int count) {
 				Boss::Msg::ResponseMoveFunds{
 					nullptr,        	// requester (see RequestMoveFunds)
 					Ln::Amount::sat(1000),  // amount_moved
-					Ln::Amount::sat(2)      // fee_spent
+					Ln::Amount::sat(1)      // fee_spent
 				});
 		})
 		.then([&bus, count]() {
@@ -118,27 +119,39 @@ int main() {
 		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "bucket_time": 1722902400,
-			  "in_earnings": 24000,
+			  "in_earnings": 48000,
 			  "in_expenditures": 0,
-			  "out_earnings": 24000,
-			  "out_expenditures": 0
+			  "out_earnings": 48000,
+			  "out_expenditures": 0,
+			  "in_forwarded": 24000000,
+			  "in_rebalanced": 0,
+			  "out_forwarded": 24000000,
+			  "out_rebalanced": 0
 			}
                 )JSON"));
 		assert(result["history"][59] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "bucket_time": 1728000000,
-			  "in_earnings": 24000,
-			  "in_expenditures": 2000,
-			  "out_earnings": 24000,
-			  "out_expenditures": 2000
+			  "in_earnings": 48000,
+			  "in_expenditures": 1000,
+			  "out_earnings": 48000,
+			  "out_expenditures": 1000,
+			  "in_forwarded": 24000000,
+			  "in_rebalanced": 1000000,
+			  "out_forwarded": 24000000,
+			  "out_rebalanced": 1000000
 			}
                 )JSON"));
 		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
 			{
-			  "in_earnings": 1440000,
-			  "in_expenditures": 14000,
-			  "out_earnings": 1440000,
-			  "out_expenditures": 14000
+			  "in_earnings": 2880000,
+			  "in_expenditures": 7000,
+			  "out_earnings": 2880000,
+			  "out_expenditures": 7000,
+			  "in_forwarded": 1440000000,
+			  "in_rebalanced": 7000000,
+			  "out_forwarded": 1440000000,
+			  "out_rebalanced": 7000000
 			}
                         )JSON"));
 		return Ev::lift();
@@ -159,27 +172,39 @@ int main() {
 		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "bucket_time": 1722902400,
-			  "in_earnings": 24000,
+			  "in_earnings": 48000,
 			  "in_expenditures": 0,
 			  "out_earnings": 0,
-			  "out_expenditures": 0
+			  "out_expenditures": 0,
+			  "in_forwarded": 24000000,
+			  "in_rebalanced": 0,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
 			}
                 )JSON"));
 		assert(result["history"][59] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "bucket_time": 1728000000,
-			  "in_earnings": 24000,
+			  "in_earnings": 48000,
 			  "in_expenditures": 0,
 			  "out_earnings": 0,
-			  "out_expenditures": 2000
+			  "out_expenditures": 1000,
+			  "in_forwarded": 24000000,
+			  "in_rebalanced": 0,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 1000000
 			}
                 )JSON"));
 		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
 			{
-			  "in_earnings": 1440000,
+			  "in_earnings": 2880000,
 			  "in_expenditures": 0,
 			  "out_earnings": 0,
-			  "out_expenditures": 14000
+			  "out_expenditures": 7000,
+			  "in_forwarded": 1440000000,
+			  "in_rebalanced": 0,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 7000000
 			}
                         )JSON"));
 		return Ev::lift();
@@ -201,26 +226,38 @@ int main() {
 			{
 			  "bucket_time": 1727481600,
 			  "in_earnings": 0,
-			  "in_expenditures": 2000,
+			  "in_expenditures": 1000,
 			  "out_earnings": 0,
-			  "out_expenditures": 0
+			  "out_expenditures": 0,
+			  "in_forwarded": 0,
+			  "in_rebalanced": 1000000,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
 			}
                 )JSON"));
 		assert(result["history"][6] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "bucket_time": 1728000000,
 			  "in_earnings": 0,
-			  "in_expenditures": 2000,
+			  "in_expenditures": 1000,
 			  "out_earnings": 0,
-			  "out_expenditures": 0
+			  "out_expenditures": 0,
+			  "in_forwarded": 0,
+			  "in_rebalanced": 1000000,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
 			}
                 )JSON"));
 		assert(result["total"] == Jsmn::Object::parse_json(R"JSON(
 			{
 			  "in_earnings": 0,
-			  "in_expenditures": 14000,
+			  "in_expenditures": 7000,
 			  "out_earnings": 0,
-			  "out_expenditures": 0
+			  "out_expenditures": 0,
+			  "in_forwarded": 0,
+			  "in_rebalanced": 7000000,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
 			}
                         )JSON"));
 		return Ev::lift();

--- a/tests/boss/test_earningstracker.cpp
+++ b/tests/boss/test_earningstracker.cpp
@@ -68,7 +68,8 @@ int main() {
 				A,			// in_id
 				B,			// out_id
 				Ln::Amount::sat(1),	// fee
-				1.0			// resolution_time
+				1.0,			// resolution_time
+				Ln::Amount::sat(1000),	// amount forwarded
 			});
 	}).then([&]() {
 		mock_now = 2000.0;
@@ -84,19 +85,31 @@ int main() {
 		    "in_earnings": 1000,
 		    "in_expenditures": 0,
 		    "out_earnings": 0,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 1000000,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 0,
+		    "out_rebalanced": 0
 		  },
 		  "020000000000000000000000000000000000000000000000000000000000000002": {
 		    "in_earnings": 0,
 		    "in_expenditures": 0,
 		    "out_earnings": 1000,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 0,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 1000000,
+		    "out_rebalanced": 0
 		  },
 		  "total": {
 		    "in_earnings": 1000,
 		    "in_expenditures": 0,
 		    "out_earnings": 1000,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 1000000,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 1000000,
+		    "out_rebalanced": 0
 		  }
 		}
                         )JSON"));
@@ -108,7 +121,8 @@ int main() {
 				A,			// in_id
 				B,			// out_id
 				Ln::Amount::sat(1),	// fee
-				1.0			// resolution_time
+				1.0,			// resolution_time
+				Ln::Amount::sat(2000),	// amount forwarded
 			});
 	}).then([&]() {
 		return bus.raise(Boss::Msg::SolicitStatus{});
@@ -123,19 +137,31 @@ int main() {
 		    "in_earnings": 2000,
 		    "in_expenditures": 0,
 		    "out_earnings": 0,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 3000000,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 0,
+		    "out_rebalanced": 0
 		  },
 		  "020000000000000000000000000000000000000000000000000000000000000002": {
 		    "in_earnings": 0,
 		    "in_expenditures": 0,
 		    "out_earnings": 2000,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 0,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 3000000,
+		    "out_rebalanced": 0
 		  },
 		  "total": {
 		    "in_earnings": 2000,
 		    "in_expenditures": 0,
 		    "out_earnings": 2000,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 3000000,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 3000000,
+		    "out_rebalanced": 0
 		  }
 		}
                         )JSON"));
@@ -171,25 +197,41 @@ int main() {
 		    "in_earnings": 2000,
 		    "in_expenditures": 0,
 		    "out_earnings": 0,
-		    "out_expenditures": 2000
+		    "out_expenditures": 2000,
+		    "in_forwarded": 3000000,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 0,
+		    "out_rebalanced": 1000000
 		  },
 		  "020000000000000000000000000000000000000000000000000000000000000002": {
 		    "in_earnings": 0,
 		    "in_expenditures": 0,
 		    "out_earnings": 2000,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 0,
+		    "in_rebalanced": 0,
+		    "out_forwarded": 3000000,
+		    "out_rebalanced": 0
 		  },
 		  "020000000000000000000000000000000000000000000000000000000000000003": {
 		    "in_earnings": 0,
 		    "in_expenditures": 2000,
 		    "out_earnings": 0,
-		    "out_expenditures": 0
+		    "out_expenditures": 0,
+		    "in_forwarded": 0,
+		    "in_rebalanced": 1000000,
+		    "out_forwarded": 0,
+		    "out_rebalanced": 0
 		  },
 		  "total": {
 		    "in_earnings": 2000,
 		    "in_expenditures": 2000,
 		    "out_earnings": 2000,
-		    "out_expenditures": 2000
+		    "out_expenditures": 2000,
+		    "in_forwarded": 3000000,
+		    "in_rebalanced": 1000000,
+		    "out_forwarded": 3000000,
+		    "out_rebalanced": 1000000
 		  }
 		}
                         )JSON"));

--- a/tests/boss/test_forwardfeemonitor.cpp
+++ b/tests/boss/test_forwardfeemonitor.cpp
@@ -140,7 +140,7 @@ int main() {
 		assert(forwardfee->out_id == Ln::NodeId("020000000000000000000000000000000000000000000000000000000000000000"));
 		assert(forwardfee->fee == Ln::Amount::msat(1001));
 		assert(forwardfee->resolution_time == (1560696342.556 - 1560696342.368));
-
+		assert(forwardfee->amount == Ln::Amount::msat(100000000));
 		return Ev::lift(0);
 	});
 


### PR DESCRIPTION
Addresses ([#229])

This allows effective feerates (PPM) to be computed for earnings and expenses.

This PR updates the schema automatically.  Downgrading to previous will require manual DB migration (but is possible).